### PR TITLE
Replace empty link to span

### DIFF
--- a/src/IPub/VisualPaginator/Components/template/bootstrap.latte
+++ b/src/IPub/VisualPaginator/Components/template/bootstrap.latte
@@ -1,22 +1,22 @@
 {if $paginator->pageCount > 1}
 <ul class="pagination">
 	{if $paginator->isFirst()}
-	<li class="disabled"><a>« Previous</a></li>
+	<li class="disabled"><span>« Previous</span></li>
 	{else}
 	<li><a href="{link $handle, 'page' => $paginator->page - 1}" rel="prev" n:class="$useAjax ? ajax">« Previous</a></li>
 	{/if}
 
 	{foreach $steps as $step}
 	{if $step == $paginator->page}
-	<li class="active"><a href="#">{$step}</a></li>
+	<li class="active"><span>{$step}</span></li>
 	{else}
 	<li><a href="{link $handle, 'page' => $step}" n:class="$useAjax ? ajax">{$step}</a></li>
 	{/if}
-	{if $iterator->nextValue > $step + 1}<li class="disabled"><a>…</a></li>{/if}
+	{if $iterator->nextValue > $step + 1}<li class="disabled"><span>…</span></li>{/if}
 	{/foreach}
 
 	{if $paginator->isLast()}
-	<li class="disabled"><a>Next »</a></li>
+	<li class="disabled"><span>Next »</span></li>
 	{else}
 	<li><a href="{link $handle, 'page' => $paginator->page + 1}" rel="next" n:class="$useAjax ? ajax">Next »</a></li>
 	{/if}

--- a/src/IPub/VisualPaginator/Components/template/default.latte
+++ b/src/IPub/VisualPaginator/Components/template/default.latte
@@ -8,22 +8,22 @@
 <div class="pagination">
 	<ul>
 		{if $paginator->isFirst()}
-		<li><a>«</a></li>
+		<li><span>«</span></li>
 		{else}
 		<li><a href="{link $handle, 'page' => $paginator->page - 1}" n:class="$useAjax ? ajax">«</a></li>
 		{/if}
 
 		{foreach $steps as $step}
 		{if $step == $paginator->page}
-			<li class="active"><a>{$step}</a></li>
+			<li class="active"><span>{$step}</span></li>
 		{else}
 			<li><a href="{link $handle, 'page' => $step}" n:class="$useAjax ? ajax">{$step}</a></li>
 		{/if}
-		{if $iterator->nextValue > $step + 1}<li class="disabled"><a>…</a></li>{/if}
+		{if $iterator->nextValue > $step + 1}<li class="disabled"><span>…</span></li>{/if}
 		{/foreach}
 
 		{if $paginator->isLast()}
-		<li><a>»</a></li>
+		<li><span>»</span></li>
 		{else}
 		<li><a href="{link $handle, 'page' => $paginator->page + 1}" n:class="$useAjax ? ajax">»</a></li>
 		{/if}

--- a/src/IPub/VisualPaginator/Components/template/foundation.latte
+++ b/src/IPub/VisualPaginator/Components/template/foundation.latte
@@ -8,23 +8,23 @@
 <div class="pagination-centered">
 	<ul class="pagination">
 		{if $paginator->isFirst()}
-		<li class="arrow unavailable"><a href="">&laquo;</a></li>
+		<li class="arrow unavailable"><span>&laquo;</span></li>
 		{else}
 		<li><a href="{link $handle, 'page' => $paginator->page - 1}" n:class="$useAjax ? ajax,arrow">&laquo;</a></li>
 		{/if}
 
 		{foreach $steps as $step}
 		{if $step == $paginator->page}
-			<li class="current"><a>{$step}</a></li>
+			<li class="current"><span>{$step}</span></li>
 		{else}
 			<li><a href="{link $handle, 'page' => $step}" n:class="$useAjax ? ajax">{$step}</a></li>
 		{/if}
-		{if $iterator->nextValue > $step + 1}<li class="unavailable"><a href="">&hellip;</a></li>{/if}
+		{if $iterator->nextValue > $step + 1}<li class="unavailable"><span>&hellip;</span></li>{/if}
 		{/foreach}
 
 		{if $paginator->isLast()}
 
-		<li class="arrow unavailable"><a href="">&raquo;</a></li>
+		<li class="arrow unavailable"><span>&raquo;</span></li>
 		{else}
 		<li><a href="{link $handle, 'page' => $paginator->page + 1}" n:class="$useAjax ? ajax,arrow">&raquo;</a></li>
 		{/if}


### PR DESCRIPTION
PR resolves a redirect problem if it is in the header:
`<base href="https://www.google.com">`
